### PR TITLE
Introduce format_rfc3339_{millis, micros}

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,5 +26,8 @@ pub use duration::{parse_duration, Error as DurationError};
 pub use duration::{format_duration, FormattedDuration};
 pub use wrapper::{Duration, Timestamp};
 pub use date::{parse_rfc3339, parse_rfc3339_weak, Error as TimestampError};
-pub use date::{format_rfc3339, format_rfc3339_seconds, format_rfc3339_nanos};
+pub use date::{
+    format_rfc3339, format_rfc3339_micros, format_rfc3339_millis, format_rfc3339_nanos,
+    format_rfc3339_seconds,
+};
 pub use date::{Rfc3339Timestamp};


### PR DESCRIPTION
Inspired by an open issue https://github.com/sebasmagri/env_logger/issues/122 needing millisecond precision. I added microseconds also since I felt bad about leaving a gap.

Now there's a complete set of sub second precisions from millis, to micros and to nanos.