### PR TITLE
Remove quick-error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_cache:
 jobs:
   include:
   - os: linux
-    rust: 1.18.0
+    rust: 1.32.0
   - os: linux
     rust: stable
   - os: linux

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,11 @@ version = "1.3.0"
 authors = ["Paul Colomiets <paul@colomiets.name>"]
 categories = ["date-and-time"]
 
-[dependencies]
-quick-error = "1.0.0"
-
 [lib]
 name = "humantime"
 path = "src/lib.rs"
 
 [dev-dependencies]
-time = "0.1.39"
-chrono = "0.4.0"
-rand = "0.4.2"
+time = "0.1"
+chrono = "0.4"
+rand = "0.7"

--- a/src/date.rs
+++ b/src/date.rs
@@ -1,3 +1,4 @@
+use std::error::Error as StdError;
 use std::fmt;
 use std::str;
 use std::time::{SystemTime, Duration, UNIX_EPOCH};
@@ -31,21 +32,25 @@ mod max {
     pub const TIMESTAMP: &'static str = "9999-12-31T23:59:59Z";
 }
 
-quick_error! {
-    /// Error parsing datetime (timestamp)
-    #[derive(Debug, PartialEq, Clone, Copy)]
-    pub enum Error {
-        /// Numeric component is out of range
-        OutOfRange {
-            display("numeric component is out of range")
-        }
-        /// Bad character where digit is expected
-        InvalidDigit {
-            display("bad character where digit is expected")
-        }
-        /// Other formatting errors
-        InvalidFormat {
-            display("timestamp format is invalid")
+/// Error parsing datetime (timestamp)
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum Error {
+    /// Numeric component is out of range
+    OutOfRange,
+    /// Bad character where digit is expected
+    InvalidDigit,
+    /// Other formatting errors
+    InvalidFormat,
+}
+
+impl StdError for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::OutOfRange => write!(f, "numeric component is out of range"),
+            Error::InvalidDigit => write!(f, "bad character where digit is expected"),
+            Error::InvalidFormat => write!(f, "timestamp format is invalid"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,6 @@
 #![warn(missing_debug_implementations)]
 #![warn(missing_docs)]
 
-#[macro_use] extern crate quick_error;
-
 mod duration;
 mod wrapper;
 mod date;


### PR DESCRIPTION
* Remove `quick-error` dependency (use std::error::Error)
* Fix compiler warnings (use ? and ..= instead of deprecated usage)