### PR TITLE
Add respository to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 keywords = ["time", "human", "human-friendly", "parser", "duration"]
 homepage = "https://github.com/tailhook/humantime"
+repository = "https://github.com/tailhook/humantime"
 documentation = "https://docs.rs/humantime"
 version = "2.0.0"
 edition = "2018"


### PR DESCRIPTION
This way there will be a link in the standard ui of `docs.rs/crates.io/lib.rs` to this repo (it also took some ~~human~~time for me to figure out the repo url)