### PR TITLE
Expose inner values from formatting wrappers

### DIFF
--- a/src/date.rs
+++ b/src/date.rs
@@ -242,8 +242,8 @@ pub fn format_rfc3339_nanos(system_time: SystemTime) -> Rfc3339Timestamp {
 
 impl Rfc3339Timestamp {
     /// Returns the [`SystemTime`][] that is being formatted.
-    pub fn system_time(&self) -> SystemTime {
-        self.0
+    pub fn get_ref(&self) -> &SystemTime {
+        &self.0
     }
 }
 

--- a/src/date.rs
+++ b/src/date.rs
@@ -241,7 +241,7 @@ pub fn format_rfc3339_nanos(system_time: SystemTime) -> Rfc3339Timestamp {
 }
 
 impl Rfc3339Timestamp {
-    /// Returns the [`SystemTime`][] that is being formatted.
+    /// Returns a reference to the [`SystemTime`][] that is being formatted.
     pub fn get_ref(&self) -> &SystemTime {
         &self.0
     }

--- a/src/date.rs
+++ b/src/date.rs
@@ -240,6 +240,13 @@ pub fn format_rfc3339_nanos(system_time: SystemTime) -> Rfc3339Timestamp {
     Rfc3339Timestamp(system_time, Precision::Nanos)
 }
 
+impl Rfc3339Timestamp {
+    /// Returns the [`SystemTime`][] that is being formatted.
+    pub fn system_time(&self) -> SystemTime {
+        self.0
+    }
+}
+
 impl fmt::Display for Rfc3339Timestamp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::Precision::*;

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -285,6 +285,13 @@ fn item(f: &mut fmt::Formatter, started: &mut bool, name: &str, value: u32)
     Ok(())
 }
 
+impl FormattedDuration {
+    /// Returns the [`Duration`][] that is being formatted.
+    pub fn duration(&self) -> Duration {
+        self.0
+    }
+}
+
 impl fmt::Display for FormattedDuration {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let secs = self.0.as_secs();

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -287,8 +287,8 @@ fn item(f: &mut fmt::Formatter, started: &mut bool, name: &str, value: u32)
 
 impl FormattedDuration {
     /// Returns the [`Duration`][] that is being formatted.
-    pub fn duration(&self) -> Duration {
-        self.0
+    pub fn get_ref(&self) -> &Duration {
+        &self.0
     }
 }
 

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -286,7 +286,7 @@ fn item(f: &mut fmt::Formatter, started: &mut bool, name: &str, value: u32)
 }
 
 impl FormattedDuration {
-    /// Returns the [`Duration`][] that is being formatted.
+    /// Returns a reference to the [`Duration`][] that is being formatted.
     pub fn get_ref(&self) -> &Duration {
         &self.0
     }


### PR DESCRIPTION
Hey! 👋

First of all, thank you for this great library!

We're using this library together with `thiserror` to provide nicely formatted durations & timestamps in our error messages, for example, like this:

```rust
#[derive(Debug, thiserror::Error)]
enum Error {
  #[error("operation timed out after {0}")]
  Timeout(FormattedDuration),
}
```

This works great, but limits programmatic usability of the error enum, since once a duration (or system time) is formatted, there is no way to access it again, because the library doesn't expose them. If we ever wanted to programmatically process timeout errors we'd need to store the duration value we're formatting as well, which isn't really nice because we'd be doubling the size of that variant and there is no static guarantee that those values are actually the same.

Therefore this PR adds two accessor methods to the formatting wrappers that expose the time values that are being formatted. 