### PR TITLE
Adding missed unit test cases

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -453,4 +453,26 @@ mod test {
             ns, us, ms, sec, min, hours, days, weeks, months, \
             years (and few variations)");
     }
+
+    #[test]
+    fn test_error_cases() {
+        assert_eq!(
+            parse_duration("\0").unwrap_err().to_string(),
+            "expected number at 0"
+        );
+        assert_eq!(
+            parse_duration("\r").unwrap_err().to_string(),
+            "value was empty"
+        );
+        assert_eq!(
+            parse_duration("1~").unwrap_err().to_string(),
+            "invalid character at 1"
+        );
+        assert_eq!(
+            parse_duration("1Nå").unwrap_err().to_string(),
+            "invalid character at 2"
+        );
+        assert_eq!(parse_duration("222nsec221nanosmsec7s5msec572s").unwrap_err().to_string(),
+                   "unknown time unit \"nanosmsec\", supported units: ns, us, ms, sec, min, hours, days, weeks, months, years (and few variations)");
+    }
 }


### PR DESCRIPTION
Hi,

Thanks for your time & patience to review this PR.

We are researchers focusing on Rust unit tests. By examine the existing code, we found a unit test can be added to improve the repo's overall unit test coverage(this project is already been well tested).
For the first 4 cases, you can easily find their error locations and for the last case, the untested area is:
https://github.com/tailhook/humantime/blob/12ce6f50894a56a410b390e5608ac9db8afe2407/src/duration.rs#L181-L187
including both the error cases and correct path.

Thanks again for reviewing.
