### PR TITLE
feat: parse_duration("0")

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -226,6 +226,9 @@ impl Parser<'_> {
 /// assert_eq!(parse_duration("32ms"), Ok(Duration::new(0, 32_000_000)));
 /// ```
 pub fn parse_duration(s: &str) -> Result<Duration, Error> {
+    if s == "0" {
+        return Ok(Duration::ZERO);
+    }
     Parser {
         iter: s.chars(),
         src: s,


### PR DESCRIPTION
This is unambiguous, so shouldn't need a suffix.
A user of `parse_duration` already isn't fastpath, so the extra branch is fine.
`Duration::ZERO` was added in 1.53, so no change to MSRV.