### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ mu = []
 
 [dev-dependencies]
 bencher = "0.1.5"
-time = { version = "0.3", features = ["formatting"] }
+time = { version = "0.3.47", features = ["formatting"] }
 chrono = "0.4"
 rand = "0.9"
 


### PR DESCRIPTION
Bumps the dependency to at least 0.3.47 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2026-0009.html)

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)