### PR TITLE
fix: avoid panic on exact nanosecond carry overflow

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -293,7 +293,7 @@ impl Parser<'_> {
 
 fn add_current(mut sec: u64, nsec: u64, out: &mut Duration) -> Result<(), Error> {
     let mut nsec = (out.subsec_nanos() as u64).add(nsec)?;
-    if nsec > 1_000_000_000 {
+    if nsec >= 1_000_000_000 {
         sec = sec.add(nsec / 1_000_000_000)?;
         nsec %= 1_000_000_000;
     }
@@ -783,6 +783,14 @@ mod test {
         );
         assert_eq!(
             parse_duration("10000000000000y"),
+            Err(Error::NumberOverflow)
+        );
+        assert_eq!(
+            parse_duration(&format!("{}s1000ms", u64::MAX)),
+            Err(Error::NumberOverflow)
+        );
+        assert_eq!(
+            parse_duration(&format!("{}s 999999999ns 1ns", u64::MAX)),
             Err(Error::NumberOverflow)
         );
     }


### PR DESCRIPTION
A PR was planned in https://github.com/chronotope/humantime/issues/66#issuecomment-4063104201, but it's been almost four months, so just creating one in the meantime.

I don't mind if this PR/branch is superseded, changed, rebased, force-pushed, cherry-picked, etc. Do whatever basically :D

Fixes https://github.com/chronotope/humantime/issues/66